### PR TITLE
Fix SchemaField description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2024-07-30
+
+### Changed
+- Fixed get_bq_schema_from_json_schema() SchemaField parameters
+
 ## [Unreleased]
 
 ### Internal
@@ -12,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.4] - 2023-10-24
 
-## Changed
+### Changed
 - Upgrade to Pydantic V2
 
 ## [1.0.2] - 2023-10-10

--- a/gbq/helpers.py
+++ b/gbq/helpers.py
@@ -36,10 +36,10 @@ def get_bq_schema_from_json_schema(source: List[Dict]) -> List[SchemaField]:
 
     for key, value in enumerate(source):
         schema_field = SchemaField(
-            str(value.get("name")),
-            str(value.get("type")),
-            value.get("mode", "NULLABLE"),
-            value.get("description", None),
+            name = str(value.get("name")),
+            field_type = str(value.get("type")),
+            mode = value.get("mode", "NULLABLE"),
+            description = value.get("description", None),
         )
 
         # Add the field to the list of fields

--- a/gbq/helpers.py
+++ b/gbq/helpers.py
@@ -33,6 +33,7 @@ def get_bq_schema_from_json_schema(source: List[Dict]) -> List[SchemaField]:
     """
     # SchemaField list
     schema: List[SchemaField] = []
+
     for key, value in enumerate(source):
         schema_field = SchemaField(
             name=str(value.get("name")),
@@ -40,11 +41,14 @@ def get_bq_schema_from_json_schema(source: List[Dict]) -> List[SchemaField]:
             mode=value.get("mode", "NULLABLE"),
             description=value.get("description", None),
         )
+
         # Add the field to the list of fields
         schema.append(schema_field)
+
         # If it is a STRUCT / RECORD field we start the recursion
         if schema_field.field_type == "RECORD":
             schema_field._fields = get_bq_schema_from_json_schema(value.get("fields", []))  # type: ignore
+
     return schema
 
 

--- a/gbq/helpers.py
+++ b/gbq/helpers.py
@@ -36,10 +36,10 @@ def get_bq_schema_from_json_schema(source: List[Dict]) -> List[SchemaField]:
 
     for key, value in enumerate(source):
         schema_field = SchemaField(
-            name = str(value.get("name")),
-            field_type = str(value.get("type")),
-            mode = value.get("mode", "NULLABLE"),
-            description = value.get("description", None),
+            name=str(value.get("name")),
+            field_type=str(value.get("type")),
+            mode=value.get("mode", "NULLABLE"),
+            description=value.get("description", None),
         )
 
         # Add the field to the list of fields

--- a/gbq/helpers.py
+++ b/gbq/helpers.py
@@ -33,7 +33,6 @@ def get_bq_schema_from_json_schema(source: List[Dict]) -> List[SchemaField]:
     """
     # SchemaField list
     schema: List[SchemaField] = []
-
     for key, value in enumerate(source):
         schema_field = SchemaField(
             name=str(value.get("name")),
@@ -41,14 +40,11 @@ def get_bq_schema_from_json_schema(source: List[Dict]) -> List[SchemaField]:
             mode=value.get("mode", "NULLABLE"),
             description=value.get("description", None),
         )
-
         # Add the field to the list of fields
         schema.append(schema_field)
-
         # If it is a STRUCT / RECORD field we start the recursion
         if schema_field.field_type == "RECORD":
             schema_field._fields = get_bq_schema_from_json_schema(value.get("fields", []))  # type: ignore
-
     return schema
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gbq"
-version = "1.0.4"
+version = "1.0.5"
 description = "Python wrapper for interacting Google BigQuery."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -73,12 +73,23 @@ def nested_json_schema():
         {"name": "username", "mode": "NULLABLE", "type": "STRING"},
         {
             "fields": [
-                {"name": "id", "mode": "NULLABLE", "type": "INTEGER"},
-                {"name": "street", "mode": "NULLABLE", "type": "STRING"},
+                {
+                    "name": "id",
+                    "mode": "NULLABLE",
+                    "type": "INTEGER",
+                    "description": "ID DESCRIPTION",
+                },
+                {
+                    "name": "street",
+                    "mode": "NULLABLE",
+                    "type": "STRING",
+                    "description": "STREET DESCRIPTION",
+                },
             ],
             "name": "address",
             "mode": "REPEATED",
             "type": "RECORD",
+            "description": "ADDRESS DESCRIPTION",
         },
     ]
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -42,10 +42,12 @@ def test_get_bq_credentials(mocker):
 
 
 def test_convert_to_bq_schema(nested_json_schema):
-    address_schema = SchemaField("address", "RECORD", "REPEATED")
+    address_schema = SchemaField(
+        "address", "RECORD", "REPEATED", None, "ADDRESS DESCRIPTION"
+    )
     address_nested_schema = [
-        SchemaField("id", "INTEGER", "NULLABLE"),
-        SchemaField("street", "STRING", "NULLABLE"),
+        SchemaField("id", "INTEGER", "NULLABLE", None, "ID DESCRIPTION"),
+        SchemaField("street", "STRING", "NULLABLE", None, "STREET DESCRIPTION"),
     ]
     address_schema._fields = address_nested_schema
     expected = [


### PR DESCRIPTION
Bug fix for `SchemaField` description. The current implementation relies on positional arguments and the 4th argument is incorrect. Adds field names to `SchemaField` call.

More detail:
- Seeing this error when a `description` is present in a schema.
```
Invalid default value expression for column {COLUMN_NAME}; Syntax error: Expected end of input but got keyword OF
```

Example bug:
```
{
	...
	"schema": [
		{
			"name": "request_id",
			"type": "INTEGER",
			"mode": "REQUIRED",
			"description": "BSM request ID"
		},
		{
			"name": "input_generation_time_in_seconds",
			"type": "NUMERIC",
			"mode": "REQUIRED",
			"description": "BSM request uuid transaction id"
		}
	]
}
```

When transformed, the schema is the following:

```
[SchemaField('request_id', 'INTEGER', 'REQUIRED', 'BSM request ID', None, (), None), SchemaField('input_generation_time_in_seconds', 'NUMERIC', 'REQUIRED', 'BSM request uuid transaction id', None, (), None)]
```

After fix, schema looks like:

```
[SchemaField('request_id', 'INTEGER', 'REQUIRED', None, 'BSM request ID', (), None), SchemaField('input_generation_time_in_seconds', 'NUMERIC', 'REQUIRED', None, 'BSM request uuid transaction id', (), None)]
```